### PR TITLE
Add RiffsAppConfig subclass for dynamic app configuration

### DIFF
--- a/bookmarks/apps.py
+++ b/bookmarks/apps.py
@@ -1,6 +1,8 @@
-from django.apps import AppConfig
+from riffs.riffs_app import RiffsAppConfig
 
 
-class BookmarksConfig(AppConfig):
+class BookmarksConfig(RiffsAppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "bookmarks"
+    has_views = True
+    is_public = True

--- a/dropfeed/apps.py
+++ b/dropfeed/apps.py
@@ -1,10 +1,12 @@
-from django.apps import AppConfig
+from riffs.riffs_app import RiffsAppConfig
 
 
-class DropfeedConfig(AppConfig):
+class DropfeedConfig(RiffsAppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'dropfeed'
     verbose_name = 'DropFeed Podcast Manager'
-    
+    has_views = True
+    is_public = False
+
     def ready(self):
         import dropfeed.models

--- a/quotes/apps.py
+++ b/quotes/apps.py
@@ -1,6 +1,8 @@
-from django.apps import AppConfig
+from riffs.riffs_app import RiffsAppConfig
 
 
-class QuotesConfig(AppConfig):
+class QuotesConfig(RiffsAppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'quotes'
+    has_views = False
+    is_public = False

--- a/riffs/riffs_app.py
+++ b/riffs/riffs_app.py
@@ -1,0 +1,53 @@
+"""
+Base AppConfig class for Riffs apps.
+
+This module provides RiffsAppConfig, a Django AppConfig subclass that adds
+metadata for Riffs apps to indicate whether they have views and whether they
+should be publicly listed.
+"""
+
+from django.apps import AppConfig
+
+
+class RiffsAppConfig(AppConfig):
+    """
+    Base AppConfig for Riffs apps.
+
+    Attributes:
+        has_views (bool): Indicates if the app has web views/UI.
+        is_public (bool): Indicates if the app should be publicly listed on the main page.
+    """
+
+    # Default values - subclasses should override these
+    has_views = False
+    is_public = False
+
+    @classmethod
+    def get_riffs_apps(cls):
+        """
+        Get all installed Riffs apps.
+
+        Returns:
+            list: List of RiffsAppConfig instances that are installed.
+        """
+        from django.apps import apps
+
+        riffs_apps = []
+        for app_config in apps.get_app_configs():
+            if isinstance(app_config, cls):
+                riffs_apps.append(app_config)
+
+        return riffs_apps
+
+    @classmethod
+    def get_public_apps_with_views(cls):
+        """
+        Get all public Riffs apps that have views.
+
+        Returns:
+            list: List of RiffsAppConfig instances that are public and have views.
+        """
+        return [
+            app for app in cls.get_riffs_apps()
+            if app.is_public and app.has_views
+        ]

--- a/riffs/settings.py
+++ b/riffs/settings.py
@@ -40,9 +40,9 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "constance",
     "taggit",
-    "bookmarks",
-    "quotes",
-    "dropfeed",
+    "bookmarks.apps.BookmarksConfig",
+    "quotes.apps.QuotesConfig",
+    "dropfeed.apps.DropfeedConfig",
 ]
 
 MIDDLEWARE = [

--- a/riffs/views.py
+++ b/riffs/views.py
@@ -1,5 +1,13 @@
 from django.shortcuts import render
+from riffs.riffs_app import RiffsAppConfig
 
 
 def index(req):
-    return render(req, "index.html")
+    """
+    Main landing page that dynamically lists all public Riffs apps.
+    """
+    riffs_apps = RiffsAppConfig.get_public_apps_with_views()
+    context = {
+        'riffs_apps': riffs_apps,
+    }
+    return render(req, "index.html", context)

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,11 @@
 <h1>Riffs</h1>
 
 <ul>
-<li><a href="/bookmarks">Bookmarks</a></li>
+{% for app in riffs_apps %}
+<li><a href="/{{ app.name }}/">{{ app.verbose_name|default:app.name|title }}</a></li>
+{% empty %}
+<li>No apps available</li>
+{% endfor %}
 </ul>
 
 


### PR DESCRIPTION
Create a Django AppConfig subclass that allows riffs apps to declare
whether they have views and should be publicly listed. The main riffs
view now dynamically discovers and displays only public apps with views.

Changes:
- Create riffs/riffs_app.py with RiffsAppConfig base class
- Add has_views and is_public fields to app configurations
- Update bookmarks, quotes, and dropfeed to use RiffsAppConfig
- Modify main view to dynamically list public apps with views
- Update index.html template to render apps dynamically
- Configure INSTALLED_APPS to use explicit AppConfig classes

App configurations:
- bookmarks: has_views=True, is_public=True (displayed)
- quotes: has_views=False, is_public=False (not displayed)
- dropfeed: has_views=True, is_public=False (not displayed)